### PR TITLE
Added support for passing Regex into CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ catch (error) {
 Via CLI:
 
 ```sh
-replace-in-file from to some/file.js,some/**/glob.js
+replace-in-file from to some/file.js,some/**/glob.js [--isRegex]
 ```
 
 The options `allowEmptyPaths` and `encoding` are supported in the CLI.
 In addition, the CLI supports the `verbose` option to list the changed files.
 
 Multiple files or globs can be replaced by providing a comma separated list.
+
+A regular expression may be used for the `from` parameter by specifying the `--isRegex` option.
 
 ## License
 (MIT License)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,9 +14,18 @@ if (argv._.length < 3) {
   process.exit(1);
 }
 
+// Parse from/to as either a Regex or a string
+const isRegexMatch = /.*\/([gimy]*)$/;
+const getRegexOrString = value => {
+  if(!isRegexMatch.test(value)) return value;
+  const flags = value.replace(/.*\/([gimy]*)$/, '$1');
+  const pattern = value.replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
+  return new RegExp(pattern, flags);
+};
+
 //Collect main arguments
-const from = argv._.shift();
-const to = argv._.shift();
+const from = getRegexOrString(argv._.shift());
+const to = getRegexOrString(argv._.shift());
 
 //Single star globs already get expanded in the command line
 const files = argv._.reduce((files, file) => {


### PR DESCRIPTION
This will allow for passing the `from`/`to` parameters as regex in the format `/match/g` through the CLI. If pattern does not match a Regex it will fall back to passing through as a `String`.