### PR TITLE
Move changedFiles logging outside of if

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -53,9 +53,8 @@ if (typeof argv.allowEmptyPaths !== 'undefined') {
 //Replace
 try {
   const changedFiles = replace.sync(options);
-  if (changedFiles.length > 0) {
-    console.log(chalk.green(changedFiles.length, 'file(s) were changed'));
-    if (argv.verbose) {
+  console.log(chalk.green(changedFiles.length, 'file(s) were changed'));
+    if (argv.verbose && (changedFiles.length > 0)) {
       changedFiles.forEach(file => console.log(chalk.grey('-', file)));
     }
   }


### PR DESCRIPTION
When the changed file was not found, there was no information from the cli which would let me know this. Because of that, an incorrect file path would be silently responded to with `"Replacing from with to"`.