### PR TITLE
RFC: Pass the filename as the 2nd argument to the to function (shift remaining existing arguments by 1 to the right)

### DIFF
--- a/lib/replace-in-file.js
+++ b/lib/replace-in-file.js
@@ -95,20 +95,23 @@ function makeReplacements(contents, from, to, file) {
   from.forEach((item, i) => {
 
     //Get replacement value
-    const replacement = getReplacement(to, isArray, i);
+    let replacement = getReplacement(to, isArray, i);
     if (replacement === null) {
       return;
     }
+    if (typeof replacement === 'function') {
+      const original = replacement;
+      replacement = function() {
+        if (typeof replacement === 'function') {
+          const args = [].slice.call(arguments);
+          args.splice(1, 0, file);
+          return original.apply(null, args);
+        }
+      };
+    }
 
     //Make replacement
-    contents = contents.replace(item, function() {
-      if (typeof replacement === 'function') {
-        const args = [].slice.call(arguments);
-        args.splice(1, 0, file);
-        return replacement.apply(null, args);
-      }
-      return replacement;
-    });
+    contents = contents.replace(item, replacement);
   });
 
   //Return modified contents

--- a/lib/replace-in-file.js
+++ b/lib/replace-in-file.js
@@ -102,11 +102,9 @@ function makeReplacements(contents, from, to, file) {
     if (typeof replacement === 'function') {
       const original = replacement;
       replacement = function() {
-        if (typeof replacement === 'function') {
-          const args = [].slice.call(arguments);
-          args.splice(1, 0, file);
-          return original.apply(null, args);
-        }
+        const args = [].slice.call(arguments);
+        args.splice(1, 0, file);
+        return original.apply(null, args);
       };
     }
 

--- a/lib/replace-in-file.js
+++ b/lib/replace-in-file.js
@@ -81,7 +81,7 @@ function getReplacement(replace, isArray, i) {
 /**
  * Helper to make replacements
  */
-function makeReplacements(contents, from, to) {
+function makeReplacements(contents, from, to, file) {
 
   //Turn into array
   if (!Array.isArray(from)) {
@@ -101,7 +101,14 @@ function makeReplacements(contents, from, to) {
     }
 
     //Make replacement
-    contents = contents.replace(item, replacement);
+    contents = contents.replace(item, function() {
+      if (typeof replacement === 'function') {
+        const args = [].slice.call(arguments);
+        args.splice(1, 0, file);
+        return replacement.apply(null, args);
+      }
+      return replacement;
+    });
   });
 
   //Return modified contents
@@ -117,7 +124,7 @@ function replaceSync(file, from, to, enc) {
   const contents = fs.readFileSync(file, enc);
 
   //Replace contents and check if anything changed
-  const newContents = makeReplacements(contents, from, to);
+  const newContents = makeReplacements(contents, from, to, file);
   if (newContents === contents) {
     return false;
   }
@@ -139,7 +146,7 @@ function replaceAsync(file, from, to, enc) {
       }
 
       //Replace contents and check if anything changed
-      let newContents = makeReplacements(contents, from, to);
+      let newContents = makeReplacements(contents, from, to, file);
       if (newContents === contents) {
         return resolve({file, hasChanged: false});
       }


### PR DESCRIPTION
I found I needed the filename to determine the correct replacement string for my use case so I added the filename as the 2nd parameter of the `to` replacement function (if it is of type 'function'). 

The change is straight forward. I haven't added any tests to .spec for it yet but thought I would check if you would be interested in merging the feature into the library before bothering.

It would break backward compatibility to anyone using more than the first argument in a `to` replacement function (which are passed in by the contents.replace(item, replacement) call).