### PR TITLE
Callback for `from`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,26 @@ const options = {
 ```
 
 ### Using callbacks for `to`
-As the `to` parameter is passed to the native [String replace method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), you can also specify a callback. This callback provides as an extra argument the name of the file in which the replacement is being performed. The following example uses a callback to convert matching strings to lowercase and appends the file extension to it:
+As the `to` parameter is passed to the native [String replace method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), you can also specify a callback. The following example uses a callback to convert matching strings to lowercase:
 
 ```js
-var path = require('path');
 const options = {
   files: 'path/to/file',
-  from: /SomePattern([A-Za-z-]+)/g,
-  to: (match, p1, offset, string, file)  => `${match.toLowerCase()}${path.extname(file)}`,
+  from: /SomePattern[A-Za-z-]+/g,
+  to: (match) => match.toLowerCase(),
+};
+```
+
+This callback provides for an extra argument above the String replace method, which is the name of the file in which the replacement is being performed. The following example replaces the matched string with the filename:
+
+```js
+const options = {
+  files: 'path/to/file',
+  from: /SomePattern[A-Za-z-]+/g,
+  to: (...args)  => {
+    const file = args.pop();
+    return file;
+  },
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A simple utility to quickly replace text in one or more files or globs. Works sy
   - [Replace all occurrences](#replace-all-occurrences)
   - [Multiple values with the same replacement](#multiple-values-with-the-same-replacement)
   - [Multiple values with different replacements](#multiple-values-with-different-replacements)
+  - [Using callbacks for `from`](#using-callbacks-for-from)
   - [Using callbacks for `to`](#using-callbacks-for-to)
   - [Ignore a single file or glob](#ignore-a-single-file-or-glob)
   - [Ignore multiple files or globs](#ignore-multiple-files-or-globs)
@@ -191,14 +192,26 @@ const options = {
 };
 ```
 
-### Using callbacks for `to`
-As the `to` parameter is passed straight to the native [String replace method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), you can also specify a callback. The following example uses a callback to convert matching strings to lowercase:
+### Using callbacks for `from`
+You can also specify a callback that returns a string or a regular expression. The callback receives the name of the file in which the replacement is being performed, thereby allowing the user to tailor the search string. The following example uses a callback to produce a search string dependent on the filename:
 
 ```js
 const options = {
   files: 'path/to/file',
-  from: /SomePattern[A-Za-z-]+/g,
-  to: (match) => match.toLowerCase(),
+  from: (file) => RegExp(`${foo('SomePattern[A-Za-z-]+', file)}`, g);,
+  to: 'bar',
+};
+```
+
+### Using callbacks for `to`
+As the `to` parameter is passed to the native [String replace method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace), you can also specify a callback. This callback provides as an extra argument the name of the file in which the replacement is being performed. The following example uses a callback to convert matching strings to lowercase and appends the file extension to it:
+
+```js
+var path = require('path');
+const options = {
+  files: 'path/to/file',
+  from: /SomePattern([A-Za-z-]+)/g,
+  to: (match, p1, offset, string, file)  => `${match.toLowerCase()}${path.extname(file)}`,
 };
 ```
 

--- a/lib/helpers/make-replacements.js
+++ b/lib/helpers/make-replacements.js
@@ -28,7 +28,8 @@ module.exports = function makeReplacements(contents, from, to, file) {
 
   //Make replacements
   from.forEach((item, i) => {
-
+    //`from` callback is called with a filename argument
+    //and returns string or regexp
     if (typeof item === 'function') {
       item = item(file);
     }
@@ -40,6 +41,7 @@ module.exports = function makeReplacements(contents, from, to, file) {
     }
     if (typeof replacement === 'function') {
       const original = replacement;
+      //`to` callback is called with an additional filename argument
       replacement = (...args) => original(...args, file);
     }
 

--- a/lib/helpers/make-replacements.js
+++ b/lib/helpers/make-replacements.js
@@ -29,6 +29,10 @@ module.exports = function makeReplacements(contents, from, to, file) {
   //Make replacements
   from.forEach((item, i) => {
 
+    if (typeof item === 'function') {
+      item = item(file);
+    }
+
     //Get replacement value
     let replacement = getReplacement(to, isArray, i);
     if (replacement === null) {

--- a/lib/replace-in-file.spec.js
+++ b/lib/replace-in-file.spec.js
@@ -82,6 +82,23 @@ describe('Replace in file', () => {
       });
     });
 
+    it('should pass file as an arg to a "from" function', done => {
+      replace({
+        files: 'test1',
+        from: (file) => {
+          expect(file).to.equal('test1');
+          return /re\splace/g;
+        },
+        to: 'b'
+      }).then(() => {
+        const test1 = fs.readFileSync('test1', 'utf8');
+        const test2 = fs.readFileSync('test2', 'utf8');
+        expect(test1).to.equal('a b c');
+        expect(test2).to.equal(testData);
+        done();
+      });
+    });
+
     it('should pass the match as first arg and file as last arg to a replacer function replace contents in a single file with regex', done => {
       replace({
         files: 'test1',
@@ -383,6 +400,23 @@ describe('Replace in file', () => {
         files: 'test1',
         from: /re\splace/g,
         to: 'b',
+      }, () => {
+        const test1 = fs.readFileSync('test1', 'utf8');
+        const test2 = fs.readFileSync('test2', 'utf8');
+        expect(test1).to.equal('a b c');
+        expect(test2).to.equal(testData);
+        done();
+      });
+    });
+
+    it('should pass file as an arg to a "from" function', done => {
+      replace({
+        files: 'test1',
+        from: (file) => {
+          expect(file).to.equal('test1');
+          return /re\splace/g;
+        },
+        to: 'b'
       }, () => {
         const test1 = fs.readFileSync('test1', 'utf8');
         const test2 = fs.readFileSync('test2', 'utf8');
@@ -701,6 +735,21 @@ describe('Replace in file', () => {
         files: 'test1',
         from: /re\splace/g,
         to: 'b',
+      });
+      const test1 = fs.readFileSync('test1', 'utf8');
+      const test2 = fs.readFileSync('test2', 'utf8');
+      expect(test1).to.equal('a b c');
+      expect(test2).to.equal(testData);
+    });
+
+    it('should pass file as an arg to a "from" function', function() {
+      replace.sync({
+        files: 'test1',
+        from: (file) => {
+          expect(file).to.equal('test1');
+          return /re\splace/g;
+        },
+        to: 'b'
       });
       const test1 = fs.readFileSync('test1', 'utf8');
       const test2 = fs.readFileSync('test2', 'utf8');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replace-in-file",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A simple utility to quickly replace text in one or more files.",
   "homepage": "https://github.com/adamreisnz/replace-in-file#readme",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replace-in-file",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "description": "A simple utility to quickly replace text in one or more files.",
   "homepage": "https://github.com/adamreisnz/replace-in-file#readme",
   "author": {


### PR DESCRIPTION
Added a callback for `from`, which takes file as an argument. Allows the user to tailor the search string according to the filename.

You may want to rename the tests of fix the language in the documentation.

Also fixed the documentation for the `to` callback.