### PR TITLE
Add types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "main": "index.js",
   "bin": "./bin/cli.js",
+  "types": "./types/index.d.ts",
   "scripts": {
     "istanbul": "babel-node ./node_modules/istanbul/lib/cli cover ./node_modules/mocha/bin/_mocha lib/**/*.spec.js",
     "test": "npm run istanbul -s",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,31 @@
+
+declare module 'replace-in-file' {
+  function replaceInFile(config: ReplaceInFileConfig): Promise<ReplaceResults>;
+  function replaceInFile(config: ReplaceInFileConfig, cb: (error: Error, results: ReplaceResults) => void): void;
+  export default replaceInFile;
+
+  namespace replaceInFile {
+    export function sync(config: ReplaceInFileConfig): ReplaceResults;
+  }
+
+  export interface ReplaceInFileConfig {
+    files: string | string[];
+    from: string | RegExp | string[] | RegExp[] | FromCallback;
+    to: string | string[] | ToCallback;
+    countMatches?: boolean;
+    allowEmptyPaths?: boolean,
+    disableGlobs?: boolean,
+    encoding?: string,
+    dry?:boolean
+  }
+
+  export interface ReplaceResults {
+    file: string;
+    hasChanged: boolean;
+    numMatches?: number,
+    numReplacements?: number,
+  }
+}
+
+type FromCallback = (file: string) => string | RegExp | string[] | RegExp[];
+type ToCallback = (match: string, file: string) => string | string[];


### PR DESCRIPTION
Resolves https://github.com/adamreisnz/replace-in-file/issues/77

This adds typescript support for this module, allowing you to use this for TypeScript projects. (Currently it will not compile as no types declaration can be found). 

This also helps users that write only in JavaScript, since editors such as VS Code can use this declaration file to suggest properties that the user may want to access in returned objects, such as the `results` object.

I currently haven't added any tests to this - what are the thoughts on testing for this? 