### PR TITLE
Bugfix quiet cli flag not working

### DIFF
--- a/lib/helpers/combine-config.js
+++ b/lib/helpers/combine-config.js
@@ -13,7 +13,7 @@ module.exports = function combineConfig(config, argv) {
   //Extract options from config
   let {
     from, to, files, ignore, encoding, verbose,
-    allowEmptyPaths, disableGlobs, isRegex, dry,
+    allowEmptyPaths, disableGlobs, isRegex, dry, quiet,
   } = config;
 
   //Get from/to parameters from CLI args if not defined in options
@@ -48,10 +48,13 @@ module.exports = function combineConfig(config, argv) {
   if (typeof dry === 'undefined') {
     dry = !!argv.dry;
   }
+  if (typeof quiet === 'undefined') {
+    quiet = !!argv.quiet;
+  }
 
   //Return through parser to validate
   return parseConfig({
     from, to, files, ignore, encoding, verbose,
-    allowEmptyPaths, disableGlobs, isRegex, dry,
+    allowEmptyPaths, disableGlobs, isRegex, dry, quiet,
   });
 };


### PR DESCRIPTION
When using the cli flag **--quiet** it's ignored. This change will make the flag work.