### PR TITLE
Fix missing ignore type in config

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ declare module 'replace-in-file' {
 
   export interface ReplaceInFileConfig {
     files: string | string[];
+    ignore: string | string[];
     from: string | RegExp | string[] | RegExp[] | FromCallback;
     to: string | string[] | ToCallback;
     countMatches?: boolean;


### PR DESCRIPTION
From the docs I understand that this should be there. I assume it uses the same type as the `files` property, one or more globs.

- [Ignore a single file or glob](https://github.com/adamreisnz/replace-in-file#ignore-a-single-file-or-glob)
- [Ignore multiple files or globs](https://github.com/adamreisnz/replace-in-file#ignore-a-single-file-or-glob)