### PR TITLE
Allows the config file to return a Promise

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,50 +11,54 @@ const combineConfig = require('../lib/helpers/combine-config');
 const errorHandler = require('../lib/helpers/error-handler');
 const successHandler = require('../lib/helpers/success-handler');
 
-//Extract parameters
-const {configFile} = argv;
+async function main() {
+  //Extract parameters
+  const {configFile} = argv;
 
-//Verify arguments
-if (argv._.length < 3 && !configFile) {
-  errorHandler('Replace in file needs at least 3 arguments');
-}
+  //Verify arguments
+  if (argv._.length < 3 && !configFile) {
+    errorHandler('Replace in file needs at least 3 arguments');
+  }
 
-//Load config and combine with passed arguments
-const config = loadConfig(configFile);
-const options = combineConfig(config, argv);
+  //Load config and combine with passed arguments
+  const config = await loadConfig(configFile);
+  const options = combineConfig(config, argv);
 
-//Extract settings
-const {from, to, files, isRegex, verbose, quiet} = options;
+  //Extract settings
+  const {from, to, files, isRegex, verbose, quiet} = options;
 
-//Single star globs already get expanded in the command line
-options.files = files.reduce((files, file) => {
-  return files.concat(file.split(','));
-}, []);
+  //Single star globs already get expanded in the command line
+  options.files = files.reduce((files, file) => {
+    return files.concat(file.split(','));
+  }, []);
 
-//If the isRegex flag is passed, convert the from parameter to a RegExp object
-if (isRegex) {
-  const flags = from.replace(/.*\/([gimyus]*)$/, '$1');
-  const pattern = from.replace(new RegExp(`^/(.*?)/${flags}$`), '$1');
+  //If the isRegex flag is passed, convert the from parameter to a RegExp object
+  if (isRegex) {
+    const flags = from.replace(/.*\/([gimyus]*)$/, '$1');
+    const pattern = from.replace(new RegExp(`^/(.*?)/${flags}$`), '$1');
+    try {
+      options.from = new RegExp(pattern, flags);
+    }
+    catch (error) {
+      errorHandler(error, 'Error creating RegExp from `from` parameter');
+    }
+  }
+
+  //Log
+  if (!quiet) {
+    console.log(`Replacing '${from}' with '${to}'`);
+  }
+
+  //Replace
   try {
-    options.from = new RegExp(pattern, flags);
+    const results = replace.sync(options);
+    if (!quiet) {
+      successHandler(results, verbose);
+    }
   }
   catch (error) {
-    errorHandler(error, 'Error creating RegExp from `from` parameter');
+    errorHandler(error);
   }
 }
 
-//Log
-if (!quiet) {
-  console.log(`Replacing '${from}' with '${to}'`);
-}
-
-//Replace
-try {
-  const results = replace.sync(options);
-  if (!quiet) {
-    successHandler(results, verbose);
-  }
-}
-catch (error) {
-  errorHandler(error);
-}
+main().catch((error) => errorHandler(error));


### PR DESCRIPTION
Allows the config file to return a `Promise`.

The change basically wraps `bin/cli.js` in an `async` function and `await`s the result of calling `loadConfig()`.

-----

Sample command:

`replace-in-file --configFile=replace-in-file.config.js`

Sample `replace-in-file.config.js` file:

```js
const simplegit = require("simple-git/promise");
const git = simplegit();

async function latestVersion() {
  const opts = {
    // latest single entry
    "-1": null,
  };
  const log = await git.log(opts);
  const { latest } = log;
  return latest.hash.substring(0, 8);
}

async function makeConfig() {
  const codeVersion = await latestVersion();
  return {
    files: "public/**/*",
    from: /@CODE_VERSION@/g,
    to: codeVersion,
  };
}

module.exports = makeConfig();
```
