### PR TITLE
Add bottleneck to rate limit Promise.all so that it can handle a larg…

### DIFF
--- a/lib/replace-in-file.js
+++ b/lib/replace-in-file.js
@@ -4,6 +4,7 @@
  * Dependencies
  */
 const chalk = require('chalk');
+const Bottleneck = require('bottleneck');
 const parseConfig = require('./helpers/parse-config');
 const getPathsSync = require('./helpers/get-paths-sync');
 const getPathsAsync = require('./helpers/get-paths-async');
@@ -35,12 +36,14 @@ function replaceInFile(config, cb) {
     console.log(chalk.yellow('Dry run, not making actual changes'));
   }
 
+  const limiter = new Bottleneck({ maxConcurrent: 5 });
+
   //Find paths
   return getPathsAsync(files, config)
 
     //Make replacements
     .then(paths => Promise.all(
-      paths.map(file => replaceAsync(file, from, to, config))
+      paths.map(file => limiter.schedule(() => replaceAsync(file, from, to, config)))
     ))
 
     //Success handler

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "coverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html"
   },
   "dependencies": {
+    "bottleneck": "^2.19.5",
     "chalk": "^4.0.0",
     "glob": "^7.1.6",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.7",
     "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.7.7",
     "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
     "babel-plugin-istanbul": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,11 @@ bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Thanks for a really helpful library! I'm using it on a deployment process that needs to swap out strings in around 10,000 files during build. On certain glob matches, this causes a failure, because Promise.all attempts to run all promises concurrently. Node fails with a memory error. This change introduces a rate-limit to Promise.all and ensures that only 5 replacement processes are running concurrently. 5 is an arbitrary number, but seems reasonable. I've verified this causes no test failures, and it results in my build process completing. However, it introduces a dependency, so you may want to take this as a helpful pointer but make your own version of what Bottleneck does.