### PR TITLE
[fix] Enable `glob` `windowsPathsNoEscape` option to fix `v7` usage on Windows

### DIFF
--- a/lib/helpers/get-paths-sync.js
+++ b/lib/helpers/get-paths-sync.js
@@ -18,8 +18,12 @@ module.exports = function getPathsSync(patterns, config) {
     return patterns;
   }
 
+  const isWindows = process.platform === 'win32';
   //Prepare glob config
-  const cfg = Object.assign({ignore}, globConfig, {nodir: true});
+  const cfg = Object.assign({ignore}, globConfig, {
+    nodir: true,
+    windowsPathsNoEscape: isWindows
+  });
 
   //Append CWD configuration if given (#56)
   //istanbul ignore if

--- a/lib/helpers/glob-async.js
+++ b/lib/helpers/glob-async.js
@@ -10,8 +10,12 @@ const glob = require('glob');
  */
 module.exports = function globAsync(pattern, ignore, allowEmptyPaths, cfg) {
 
+  const isWindows = process.platform === 'win32';
   //Prepare glob config
-  cfg = Object.assign({ignore}, cfg, {nodir: true});
+  cfg = Object.assign({ignore}, cfg, {
+    nodir: true,
+    windowsPathsNoEscape: isWindows
+  });
 
   //Return promise
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes broken `v7` usage on Windows OS when nodejs [path.join()](https://nodejs.org/api/path.html#pathjoinpaths) is used to create file paths.

More info: #165

Also:
- https://github.com/ngneat/transloco/issues/700
- https://github.com/isaacs/minimatch#unc-paths