### PR TITLE
Export 'replaceInFile' namespace.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ declare module 'replace-in-file' {
   export function replaceInFile(config: ReplaceInFileConfig, cb: (error: Error, results: ReplaceResult[]) => void): void;
   export default replaceInFile;
 
-  namespace replaceInFile {
+  export namespace replaceInFile {
     export function sync(config: ReplaceInFileConfig): ReplaceResult[];
     export function replaceInFileSync(config: ReplaceInFileConfig): ReplaceResult[];
     export function replaceInFile(config: ReplaceInFileConfig): Promise<ReplaceResult[]>;


### PR DESCRIPTION
I fixed the issue, so the replaceInFile namespace wasn't exported.

I reported this issue in the #172 issue.