### PR TITLE
Custom processor with two arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The custom processor will receive the path of the file being processed as a seco
 ```js
 const results = replace.sync({
   files: 'path/to/files/*.html',
-  processor: (input, file) => input.replace(/foo/g, 'bar') + file,
+  processor: (input, file) => input.replace(/foo/g, file),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ const results = replace.sync({
   processor: (input) => input.replace(/foo/g, 'bar'),
 });
 ```
+It's also possible to use a custom processor with two arguments. In this case the first argument of the callback is still the content to be processed. The second one receives the file being processed.
+
+```js
+const results = replace.sync({
+  files: 'path/to/files/*.html',
+  processor: (input, file) => input.replace(/foo/g, 'bar') + file,
+});
+```
 
 ### Array of custom processors
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ const results = replace.sync({
   processor: (input) => input.replace(/foo/g, 'bar'),
 });
 ```
-It's also possible to use a custom processor with two arguments. In this case the first argument of the callback is still the content to be processed. The second one receives the file being processed.
+The custom processor will receive the path of the file being processed as a second parameter:
 
 ```js
 const results = replace.sync({

--- a/lib/helpers/run-processors.js
+++ b/lib/helpers/run-processors.js
@@ -6,10 +6,7 @@ module.exports = function runProcessors(contents, processor, file) {
   const result = {file};
 
   const newContents = processors.reduce((contents, processor) => {
-    if (processor.length === 2) {
-      return processor(contents, file);
-    }
-    return processor(contents);
+    return processor(contents, file);
   }, contents);
 
   result.hasChanged = (newContents !== contents);

--- a/lib/helpers/run-processors.js
+++ b/lib/helpers/run-processors.js
@@ -6,6 +6,9 @@ module.exports = function runProcessors(contents, processor, file) {
   const result = {file};
 
   const newContents = processors.reduce((contents, processor) => {
+    if (processor.length === 2) {
+      return processor(contents, file);
+    }
     return processor(contents);
   }, contents);
 

--- a/lib/process-file.spec.js
+++ b/lib/process-file.spec.js
@@ -770,7 +770,7 @@ describe('Process a file', () => {
       const test3 = fs.readFileSync('test3', 'utf8');
       expect(test1).to.equal(`${testData}test1`);
       expect(test2).to.equal(`${testData}test2`);
-      expect(test3).to.equal(  'nopetest3');
+      expect(test3).to.equal('nopetest3');
     });
 
     describe('fs', () => {

--- a/lib/process-file.spec.js
+++ b/lib/process-file.spec.js
@@ -42,6 +42,13 @@ describe('Process a file', () => {
     return config;
   }
 
+  function appendFileProcessor(config) {
+    config.processor = (content, file) => {
+      return content + file;
+    };
+    return config;
+  }
+
   /**
    * Async with promises
    */
@@ -752,6 +759,18 @@ describe('Process a file', () => {
       expect(results[1].hasChanged).to.equal(true);
       expect(results[2].file).to.equal('test3');
       expect(results[2].hasChanged).to.equal(false);
+    });
+
+    it('should pass filename to processor as second parameter', () => {
+      transform.sync(appendFileProcessor({
+        files: 'test*',
+      }));
+      const test1 = fs.readFileSync('test1', 'utf8');
+      const test2 = fs.readFileSync('test2', 'utf8');
+      const test3 = fs.readFileSync('test3', 'utf8');
+      expect(test1).to.equal(testData + 'test1');
+      expect(test2).to.equal(testData + 'test2');
+      expect(test3).to.equal(  'nopetest3');
     });
 
     describe('fs', () => {

--- a/lib/process-file.spec.js
+++ b/lib/process-file.spec.js
@@ -768,8 +768,8 @@ describe('Process a file', () => {
       const test1 = fs.readFileSync('test1', 'utf8');
       const test2 = fs.readFileSync('test2', 'utf8');
       const test3 = fs.readFileSync('test3', 'utf8');
-      expect(test1).to.equal(testData + 'test1');
-      expect(test2).to.equal(testData + 'test2');
+      expect(test1).to.equal(`${testData}test1`);
+      expect(test2).to.equal(`${testData}test2`);
       expect(test3).to.equal(  'nopetest3');
     });
 

--- a/lib/process-file.spec.js
+++ b/lib/process-file.spec.js
@@ -44,7 +44,7 @@ describe('Process a file', () => {
 
   function appendFileProcessor(config) {
     config.processor = (content, file) => {
-      return content + file;
+      return `${content}${file}`;
     };
     return config;
   }


### PR DESCRIPTION
Extend custom processors: Support callbacks with two arguments:
1. Content to be processed
2. Filename which is processed