### PR TITLE
Added Regex type 'To' type so that both from and to string can be regex

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,7 +15,7 @@ declare module 'replace-in-file' {
   export function replaceInFileSync(config: ReplaceInFileConfig): ReplaceResult[];
 
   export type From = string | RegExp | FromCallback;
-  export type To = string | ToCallback;
+  export type To = string | RegExp | ToCallback;
 
   export interface ReplaceInFileConfig {
     files: string | string[];
@@ -26,8 +26,8 @@ declare module 'replace-in-file' {
     allowEmptyPaths?: boolean,
     disableGlobs?: boolean,
     encoding?: string,
-    dry?:boolean
-    glob?:object
+    dry?: boolean
+    glob?: object
   }
 
   export interface ReplaceResult {


### PR DESCRIPTION
In typescript 'to' parameter was restricted to only string, but in general this works very well with RegExp as well. This is edited and used in one of my projects. 
This resolves #166 (Same person with different account)