### PR TITLE
Multiple Replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,31 @@ yarn add replace-in-file
 ```js
 //Load the library and specify options
 const replace = require('replace-in-file');
+
+// 'options' could be single config object or an array collection for multiple replacements
+
+// Single config object
 const options = {
   files: 'path/to/file',
   from: /foo/g,
   to: 'bar',
 };
+
+(or)
+
+// Config collection for multiple replacements
+const options = [
+  {
+    files: 'path/to/file1',
+    from: /foo/g,
+    to: 'bar',
+  },
+  {
+    files: 'path/to/file2',
+    from: /bar/g,
+    to: 'foo',
+  }
+];
 ```
 
 ### Asynchronous replacement with `async`/`await`

--- a/lib/process-file.js
+++ b/lib/process-file.js
@@ -42,9 +42,7 @@ function processFile(config, cb) {
       if (typeof cb === 'function') {
         cb(error);
       }
-      else {
-        throw error;
-      }
+      throw new Error(error);
     });
 }
 

--- a/lib/replace-in-file.js
+++ b/lib/replace-in-file.js
@@ -10,85 +10,105 @@ const processFile = require('./process-file');
 /**
  * Replace in file helper
  */
-function replaceInFile(config, cb) {
+async function replaceInFile(configCollection, cb) {
+  // If 'configCollection' is passed as object, wrapping it with array
+  const tempConfigCollection = Array.isArray(configCollection) ? configCollection : [configCollection];
 
-  // If custom processor is provided use it instead
-  if (config && config.processor) {
-    return processFile(config, cb);
-  }
-
-  //Parse config
   try {
-    config = parseConfig(config);
-  }
-  catch (error) {
-    if (typeof cb === 'function') {
-      return cb(error, null);
-    }
-    return Promise.reject(error);
-  }
-
-  //Get config
-  const {files, from, to, dry, verbose} = config;
-
-  //Dry run?
-  //istanbul ignore if: No need to test console logs
-  if (dry && verbose) {
-    console.log(chalk.yellow('Dry run, not making actual changes'));
-  }
-
-  //Find paths
-  return getPathsAsync(files, config)
-
-    //Make replacements
-    .then(paths => Promise.all(
-      paths.map(file => replaceAsync(file, from, to, config))
-    ))
-
-    //Success handler
-    .then(results => {
-      if (typeof cb === 'function') {
-        cb(null, results);
+    const resultPromiseCollection = tempConfigCollection.map((config) => {
+      // If custom processor is provided use it instead
+      if (config && config.processor) {
+        return processFile(config, cb);
       }
-      return results;
-    })
 
-    //Error handler
-    .catch(error => {
-      if (typeof cb === 'function') {
-        cb(error);
+      //Parse config
+      try {
+        config = parseConfig(config);
       }
-      else {
-        throw error;
+      catch (error) {
+        if (typeof cb === 'function') {
+          return cb(error, null);
+        }
+        return Promise.reject(error);
       }
+
+      //Get config
+      const {files, from, to, dry, verbose} = config;
+
+      //Dry run?
+      //istanbul ignore if: No need to test console logs
+      if (dry && verbose) {
+        console.log(chalk.yellow('Dry run, not making actual changes'));
+      }
+
+      //Find paths
+      return getPathsAsync(files, config)
+
+        //Make replacements
+        .then(paths => Promise.all(
+          paths.map(file => replaceAsync(file, from, to, config))
+        ))
+
+        //Success handler
+        .then(results => {
+          if (typeof cb === 'function') {
+            cb(null, results);
+          }
+          return results;
+        })
+
+        //Error handler
+        .catch(error => {
+          if (typeof cb === 'function') {
+            cb(error);
+          }
+          throw new Error(error);
+        });
     });
+
+    // await for result promise to get settled
+    const resultCollection = await Promise.all(resultPromiseCollection);
+
+    // Flattening the resultCollection to 1 level depth
+    return resultCollection.flat();
+  }
+  catch(error) {
+    throw new Error(error);
+  }
 }
 
 /**
  * Sync API
  */
-function replaceInFileSync(config) {
+function replaceInFileSync(configCollection) {
+  // If 'configCollection' is passed as object, wrapping it with array
+  const tempConfigCollection = Array.isArray(configCollection) ? configCollection : [configCollection];
+  
+  const resultCollection = tempConfigCollection.map((config) => {
+    //If custom processor is provided use it instead
+    if (config && config.processor) {
+      return processFile.processFileSync(config);
+    }
 
-  //If custom processor is provided use it instead
-  if (config && config.processor) {
-    return processFile.processFileSync(config);
-  }
+    //Parse config
+    config = parseConfig(config);
 
-  //Parse config
-  config = parseConfig(config);
+    //Get config, paths, and initialize changed files
+    const {files, from, to, dry, verbose} = config;
+    const paths = getPathsSync(files, config);
 
-  //Get config, paths, and initialize changed files
-  const {files, from, to, dry, verbose} = config;
-  const paths = getPathsSync(files, config);
+    //Dry run?
+    //istanbul ignore if: No need to test console logs
+    if (dry && verbose) {
+      console.log(chalk.yellow('Dry run, not making actual changes'));
+    }
 
-  //Dry run?
-  //istanbul ignore if: No need to test console logs
-  if (dry && verbose) {
-    console.log(chalk.yellow('Dry run, not making actual changes'));
-  }
+    //Process synchronously and return results
+    return paths.map(path => replaceSync(path, from, to, config));
+  });
 
-  //Process synchronously and return results
-  return paths.map(path => replaceSync(path, from, to, config));
+  // Flattening the resultCollection to 1 level depth
+  return resultCollection.flat();
 }
 
 // Self-reference to support named import

--- a/lib/replace-in-file.spec.js
+++ b/lib/replace-in-file.spec.js
@@ -46,6 +46,18 @@ describe('Replace in file', () => {
       return expect(replace(42)).to.eventually.be.rejectedWith(Error);
     });
 
+    it('should throw an error when invalid config provided even for one item in the config collection', () => {
+      return expect(replace([
+        {
+          files: 'test1',
+          from: /re\splace/g,
+          to: 'b',
+        },
+        {},
+      ]))
+      .to.eventually.be.rejectedWith(Error);
+    });
+
     it('should throw an error when no `files` defined', () => {
       return expect(replace({
         from: /re\splace/g,
@@ -246,6 +258,24 @@ describe('Replace in file', () => {
       });
     });
 
+    it('should return a results array as expected for an array of config collection', done => {
+      replace([{
+        files: 'test1',
+        from: /re\splace/g,
+        to: 'b',
+      }, {
+        files: 'test2',
+        from: /re\splace/g,
+        to: 'b',
+      }]).then(results => {
+        expect(results).to.be.instanceof(Array);
+        expect(results).to.have.length(2);
+        expect(results[0].file).to.equal('test1');
+        expect(results[1].file).to.equal('test2');
+        done();
+      });
+    });
+
     it('should mark if something was replaced', done => {
       replace({
         files: 'test1',
@@ -281,6 +311,30 @@ describe('Replace in file', () => {
         expect(results[1].hasChanged).to.equal(true);
         expect(results[2].file).to.equal('test3');
         expect(results[2].hasChanged).to.equal(false);
+        done();
+      });
+    });
+
+    it('should return correct results for multiple files with config collection as an array', done => {
+      replace([{
+        files: ['test1', 'test2', 'test3'],
+        from: /re\splace/g,
+        to: 'b',
+      }, {
+        files: 'test4',
+        from: 'app',
+        to: 'testApp',
+      }
+      ]).then(results => {
+        expect(results).to.have.length(4);
+        expect(results[0].file).to.equal('test1');
+        expect(results[0].hasChanged).to.equal(true);
+        expect(results[1].file).to.equal('test2');
+        expect(results[1].hasChanged).to.equal(true);
+        expect(results[2].file).to.equal('test3');
+        expect(results[2].hasChanged).to.equal(false);
+        expect(results[3].file).to.equal('test4');
+        expect(results[3].hasChanged).to.equal(true);
         done();
       });
     });
@@ -957,6 +1011,22 @@ describe('Replace in file', () => {
       expect(test2).to.equal('a b c');
     });
 
+    it('should support configs as an array of config collection', function() {
+      replace.sync([{
+        files: 'test1',
+        from: /re\splace/g,
+        to: 'b',
+      }, {
+        files: 'test2',
+        from: /re\splace/g,
+        to: 'd',
+      }]);
+      const test1 = fs.readFileSync('test1', 'utf8');
+      const test2 = fs.readFileSync('test2', 'utf8');
+      expect(test1).to.equal('a b c');
+      expect(test2).to.equal('a d c');
+    });
+
     it('should expand globs', function() {
       replace.sync({
         files: 'test*',
@@ -978,6 +1048,23 @@ describe('Replace in file', () => {
       expect(results).to.be.instanceof(Array);
       expect(results).to.have.length(1);
       expect(results[0].file).to.equal('test1');
+    });
+
+    it('should return valid results array for an array of config collection', function() {
+      const results = replace.sync([{
+          files: ['test1', 'test2'],
+          from: /re\splace/g,
+          to: 'b',
+        }, {
+          files: 'test3',
+          from: 'nope',
+          to: 'Hello World',
+        }]);
+      expect(results).to.be.instanceof(Array);
+      expect(results).to.have.length(3);
+      expect(results[0].file).to.equal('test1');
+      expect(results[1].file).to.equal('test2');
+      expect(results[2].file).to.equal('test3');
     });
 
     it('should mark if something was replaced', function() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare module 'replace-in-file' {
   export type From = string | RegExp | FromCallback;
   export type To = string | ToCallback;
 
-  export interface ReplaceInFileConfig {
+  export interface ReplaceInFileConfigObj {
     files: string | string[];
     ignore?: string | string[];
     from: From | Array<From>;
@@ -29,6 +29,8 @@ declare module 'replace-in-file' {
     dry?:boolean
     glob?:object
   }
+
+  type ReplaceInFileConfig = ReplaceInFileConfigObj | ReplaceInFileConfigObj[];
 
   export interface ReplaceResult {
     file: string;


### PR DESCRIPTION
Config options could either be an object as before or an array collection for multiple replacements.
Updated 'README.md' file and 'index.d.ts' file for config type changes.