### PR TITLE
feat: Add processor cb type with function overloads

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,11 @@
 
 declare module 'replace-in-file' {
-  export function replaceInFile(config: ReplaceInFileConfig): Promise<ReplaceResult[]>;
-  export function replaceInFile(config: ReplaceInFileConfig, cb: (error: Error, results: ReplaceResult[]) => void): void;
+  export function replaceInFile(config: ReplaceInFileConfig & { from?: never, to?: never, processor: ReplaceInFileConfig["processor"] }): Promise<ReplaceResult[]>;
+  export function replaceInFile(config: ReplaceInFileConfig & { from?: never, to?: never, processor: ReplaceInFileConfig["processor"] }, cb: (error: Error, results: ReplaceResult[]) => void): void;
+
+  export function replaceInFile(config: ReplaceInFileConfig & { from: ReplaceInFileConfig["from"], to: ReplaceInFileConfig["to"], processor?: never }): Promise<ReplaceResult[]>;
+  export function replaceInFile(config: ReplaceInFileConfig & { from: ReplaceInFileConfig["from"], to: ReplaceInFileConfig["to"], processor?: never }, cb: (error: Error, results: ReplaceResult[]) => void): void;
+
   export default replaceInFile;
 
   export namespace replaceInFile {
@@ -20,14 +24,15 @@ declare module 'replace-in-file' {
   export interface ReplaceInFileConfig {
     files: string | string[];
     ignore?: string | string[];
-    from: From | Array<From>;
-    to: To | Array<To>;
+    from?: From | Array<From>;
+    to?: To | Array<To>;
     countMatches?: boolean;
-    allowEmptyPaths?: boolean,
-    disableGlobs?: boolean,
-    encoding?: string,
-    dry?:boolean
-    glob?:object
+    allowEmptyPaths?: boolean;
+    disableGlobs?: boolean;
+    encoding?: string;
+    dry?: boolean;
+    glob?: object;
+    processor?: ProcessorCallback | Array<ProcessorCallback>;
   }
 
   export interface ReplaceResult {
@@ -40,3 +45,4 @@ declare module 'replace-in-file' {
 
 type FromCallback = (file: string) => string | RegExp | (RegExp | string)[];
 type ToCallback = (match: string, file: string) => string | string[];
+type ProcessorCallback = (input: string, file: string) => string;


### PR DESCRIPTION
This pr would resolve #170 

- Add `processor` callback to ts types.

With these changes typescript intellisense would let user either pass the `from` and `to` options OR the `processor` callback (along side other options such as `files` or `dry` and etc.).