### PR TITLE
fix: missing getTargetFile type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,7 @@ declare module 'replace-in-file' {
     ignore?: string | string[];
     from?: From | Array<From>;
     to?: To | Array<To>;
+    getTargetFile?(source: string): string;
     countMatches?: boolean;
     allowEmptyPaths?: boolean;
     disableGlobs?: boolean;


### PR DESCRIPTION
This PR adds the `getTargetFile` option which is missing from the type definition. 

https://github.com/adamreisnz/replace-in-file/blob/fc5af6d35f046a9d70d68795a89c0afbca4511a2/src/helpers/config.js#L112

For now I'm patching in my own code like this:

```ts
import "replace-in-file";

declare module "replace-in-file" {
  export interface ReplaceInFileConfig {
    getTargetFile?(source: string): string;
  }
}
```