### PR TITLE
fix: only convert slash-wrapped strings to regex in stringToRegex

### DIFF
--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -27,17 +27,15 @@ export function stringToRegex(str) {
     return str.map(stringToRegex)
   }
 
-  //Not a string, or no match
-  const regexMatch = /.*\/([gimyus]*)$/
-  if (typeof str !== 'string' || !str.match(regexMatch)) {
+  //Not a string, or not wrapped in slashes like /pattern/flags
+  const regexMatch = /^\/(.*)\/([gimyus]*)$/s
+  const match = (typeof str === 'string') ? str.match(regexMatch) : null
+  if (!match) {
     return str
   }
 
-  //Extract flags and pattern
-  const flags = str.replace(/.*\/([gimyus]*)$/, '$1')
-  const pattern = str.replace(new RegExp(`^/(.*?)/${flags}$`), '$1')
-
-  //Return regex
+  //Extract pattern and flags and return regex
+  const [, pattern, flags] = match
   return new RegExp(pattern, flags)
 }
 

--- a/src/helpers/config.spec.js
+++ b/src/helpers/config.spec.js
@@ -1,6 +1,6 @@
 import {expect, use, should} from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import {loadConfig, combineConfig, parseConfig} from './config.js'
+import {loadConfig, combineConfig, parseConfig, stringToRegex} from './config.js'
 import fs from 'node:fs'
 
 //Enable should assertion style for usage with chai-as-promised
@@ -45,6 +45,37 @@ describe('helpers/config.js', () => {
 
       //Clean up
       fs.unlinkSync('config.json')
+    })
+  })
+
+  /**
+   * String to regex
+   */
+  describe('stringToRegex()', () => {
+
+    it('should convert strings wrapped in slashes to a regex', () => {
+      expect(stringToRegex('/cat/g')).to.eql(/cat/g)
+      expect(stringToRegex('/cat/')).to.eql(/cat/)
+      expect(stringToRegex('/^foo.*bar$/gim')).to.eql(/^foo.*bar$/gim)
+    })
+
+    it('should convert arrays of strings', () => {
+      expect(stringToRegex(['/cat/g', 'dog'])).to.eql([/cat/g, 'dog'])
+    })
+
+    it('should leave strings without a leading slash untouched', () => {
+      expect(stringToRegex('assets/img')).to.equal('assets/img')
+      expect(stringToRegex('src/gui')).to.equal('src/gui')
+      expect(stringToRegex('path/to/g')).to.equal('path/to/g')
+      expect(stringToRegex('foo/')).to.equal('foo/')
+      expect(stringToRegex('1.2/')).to.equal('1.2/')
+      expect(stringToRegex('plain')).to.equal('plain')
+    })
+
+    it('should leave non-string values untouched', () => {
+      expect(stringToRegex(/cat/g)).to.eql(/cat/g)
+      expect(stringToRegex(42)).to.equal(42)
+      expect(stringToRegex(undefined)).to.equal(undefined)
     })
   })
 


### PR DESCRIPTION
## Summary

Found during a security review of the package. `stringToRegex()` in `src/helpers/config.js` decided whether a string is a regex by checking only that it **ends** with `/` plus optional flags (`/.*\/([gimyus]*)$/`). Since `parseConfig()` runs every `from` value through it, perfectly ordinary replacement strings were silently compiled into regexes:

| `from` value | Became | Effect |
|---|---|---|
| `'assets/img'` | `/assets\/img/gim` | `img` parsed as flags → global + case-insensitive + multiline replace |
| `'src/gui'` | `/src\/gui/giu` | `gui` parsed as flags |
| `'path/to/g'` | `/path\/to\/g/g` | global replace instead of first occurrence |
| `'1.2/'` | `/1.2\//` | `.` matches any character, e.g. also `'1x2/'` |

Impact:
- **Correctness**: strings containing `/` where the last segment happens to consist of regex-flag letters (`img`, `gui`, `us`, `s`, …) replaced the wrong content, all occurrences, and/or case-insensitively.
- **Security (minor)**: if a `from` string is constructed from untrusted input, this acted as a regex-injection vector — metacharacters were interpreted and attacker-chosen flags applied, with unintended-replacement and pathological-regex (ReDoS-style) implications.

## Fix

A string is now only converted when it matches the documented `/pattern/flags` form with **both** a leading and a trailing slash, which is exactly what the README specifies (*“ensure that it starts with a `/`”*). Conversion of legitimately slash-wrapped strings (e.g. `'/cat/g'`) is unchanged.

Note: this is technically a behaviour change for anyone accidentally relying on the old misdetection, so it may warrant a minor/major release rather than a patch.

## Tests

Added a `stringToRegex()` spec covering slash-wrapped conversion, arrays, the previously-misdetected strings, and non-string passthrough. All 127 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)