### PR TITLE
v9.0.0: upgrade chalk to 6.x, drop Node 18/20 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 9.0.0
+The package now requires Node 22.12.0 or higher, as Node 18 and Node 20 have reached end of life. If you need support for older versions of Node, please use version 8.x.x.
+
+### Breaking changes
+- Node 22.12.0 or higher is now required (dependencies `yargs@18` and `chalk@6` require it)
+- Strings passed to `from` are now only converted to a regular expression if they both start and end with a slash (e.g. `"/cat/g"`), as documented. Previously, plain strings that merely ended in a slash and optional flag characters (e.g. `"assets/img"` or `"foo/"`) were silently converted to regular expressions as well.
+
+### Other changes
+- Upgraded all dependencies, including chalk to 6.x
+- The repository now uses pnpm as its package manager
+
 ## 8.0.0
 The package has been converted to an ES module and now requires Node 18 or higher. If you need support for Node 16 or below, please use version 7.x.x.
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,9 @@ replace-in-file $(ls l {,**/}*)  --configFile=config.json
 ```
 
 ## Version information
-From version 8.0.0 onwards, this package requires Node 18 or higher. If you need support for older versions of Node, please use a previous version of this package.
+From version 9.0.0 onwards, this package requires Node 22.12.0 or higher, as older versions of Node have reached end of life. If you need support for older versions of Node, please use a previous version of this package.
+
+From version 8.0.0 onwards, this package requires Node 18 or higher.
 
 As 8.0.0 was a significant rewrite, please [open an issue](https://github.com/adamreisnz/replace-in-file/issues) if you run into any problems or unexpected behaviour.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replace-in-file",
   "type": "module",
-  "version": "8.4.0",
+  "version": "9.0.0",
   "description": "A simple utility to quickly replace text in one or more files.",
   "homepage": "https://github.com/adamreisnz/replace-in-file#readme",
   "author": {
@@ -27,7 +27,7 @@
   "bin": "./bin/cli.js",
   "types": "./types/index.d.ts",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "test": "mocha 'src/**/*.spec.js'",
@@ -42,7 +42,7 @@
     "index.js"
   ],
   "dependencies": {
-    "chalk": "^5.6.2",
+    "chalk": "^6.0.0",
     "glob": "^13.0.6",
     "yargs": "^18.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^6.0.0
+        version: 6.0.0
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -228,9 +228,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -879,7 +879,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
+  chalk@6.0.0: {}
 
   check-error@2.1.3: {}
 


### PR DESCRIPTION
## Summary

Major version bump to **9.0.0** with the remaining major dependency upgrade and an engines correction.

- **chalk** `^5.6.2` → `^6.0.0` — the only dependency that still had a newer major (everything else is already on its latest major after #216; `pnpm outdated` is clean)
- **engines.node** `>=20.19.0` → `>=22.12.0` — Node 18 and 20 are both EOL. The floor is 22.12.0 rather than 22.0.0 because yargs 18 supports `^22.12.0 || >=23` on the 22.x line (chalk 6 requires `>=22`)
- **version** `8.4.0` → `9.0.0`
- CHANGELOG entry for 9.0.0 — this also documents the `stringToRegex` behaviour fix from #217, which ships in this release
- README version information section updated

## Verification
- All 127 tests pass
- `pnpm outdated` reports nothing — every dependency is on its latest version
- `pnpm audit`: no vulnerabilities
- CLI smoke-tested with chalk 6 (plain and `--verbose` output)

> **Stacked PR** — based on #218 (pnpm switch). Merge #218 first; this PR's base will then retarget to `main`. Merging this PR does not publish anything; run `npm version`/publish as usual when ready to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)