### PR TITLE
Add CI workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "test": "mocha 'src/**/*.spec.js'",
+    "lint": "eslint .",
     "coverage": "c8 npm run test",
     "postcoverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html",
     "postversion": "git push && git push --tags && npm publish"


### PR DESCRIPTION
## Summary

Adds the automation suggested in the recent security review — the repo previously had no CI at all.

### CI workflow (`.github/workflows/ci.yml`)
- Runs on pushes to `main` and on all pull requests
- Matrix: Node **22.x** and **24.x** (matches the new `engines` floor from #219)
- Installs with `pnpm install --frozen-lockfile`, then runs `pnpm run lint` and `pnpm test`
- Security posture: `permissions: contents: read` (no default write token), and all actions are **pinned to commit SHAs** (with version comments) so a hijacked action tag can't inject code into the build

### Dependabot (`.github/dependabot.yml`)
- Weekly npm dependency updates (works with `pnpm-lock.yaml`)
- Weekly GitHub Actions updates — Dependabot understands SHA pins and will bump the pinned SHA + version comment together

### Misc
- Added a `lint` script (`eslint .`) to package.json — eslint was a devDependency with no script, and CI needs an entry point

> **Stacked PR** — based on #219 (v9 bump), which is based on #218 (pnpm switch). Merge order: #218 → #219 → this. The workflow will start running on PRs as soon as this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)