### PR TITLE
Publish releases via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm test
+      # Trusted publishing requires npm 11.5.1 or higher
+      - run: npm install -g npm@latest
+      # Publishes via OIDC (no token) and generates provenance automatically
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint .",
     "coverage": "c8 npm run test",
     "postcoverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html",
-    "postversion": "git push && git push --tags && npm publish"
+    "postversion": "git push && git push --tags"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary

Moves publishing from your laptop to GitHub Actions using npm **trusted publishing** (OIDC) with automatic **provenance** attestations. After this, no npm token exists anywhere — not on your machine, not in GitHub secrets — and every published version carries a signed attestation linking it to the exact commit and workflow run that built it (visible as the Provenance badge on npmjs.com, verifiable via `npm audit signatures`).

### Changes
- **`.github/workflows/release.yml`** — triggers on `v*` tag pushes; runs lint + tests, then `npm publish`. Uses `id-token: write` for OIDC, actions pinned to commit SHAs, and upgrades the npm CLI first (trusted publishing needs npm ≥ 11.5.1)
- **`package.json`** — `postversion` is now just `git push && git push --tags`; the tag push triggers the release workflow

### Release flow after this merges
1. `npm version major` (or minor/patch) locally, as you do today
2. `postversion` pushes the commit + tag
3. The Release workflow tests and publishes automatically

### ⚠️ One-time setup required on npmjs.com (before the next release)
On [npmjs.com → replace-in-file → Settings](https://www.npmjs.com/package/replace-in-file/access) → **Trusted Publisher**, select **GitHub Actions** and enter exactly:
- **Organization or user**: `adamreisnz`
- **Repository**: `replace-in-file`
- **Workflow filename**: `release.yml`
- **Environment name**: leave blank

Until that's configured, the workflow's publish step will fail with an auth error (nothing gets published — safe failure). Once it works, consider also setting the package to *Require two-factor authentication or an automation or granular access token* → ideally **disallow tokens entirely** ("Trusted publisher only") so OIDC becomes the *only* way to publish.

> **Stacked PR** — based on #220 (CI). Merge order: #218 → #219 → #220 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)