### PR TITLE
v9.0.0, CI workflow, and trusted publishing (re-targeted to main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm test
+      # Trusted publishing requires npm 11.5.1 or higher
+      - run: npm install -g npm@latest
+      # Publishes via OIDC (no token) and generates provenance automatically
+      - run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 9.0.0
+The package now requires Node 22.12.0 or higher, as Node 18 and Node 20 have reached end of life. If you need support for older versions of Node, please use version 8.x.x.
+
+### Breaking changes
+- Node 22.12.0 or higher is now required (dependencies `yargs@18` and `chalk@6` require it)
+- Strings passed to `from` are now only converted to a regular expression if they both start and end with a slash (e.g. `"/cat/g"`), as documented. Previously, plain strings that merely ended in a slash and optional flag characters (e.g. `"assets/img"` or `"foo/"`) were silently converted to regular expressions as well.
+
+### Other changes
+- Upgraded all dependencies, including chalk to 6.x
+- The repository now uses pnpm as its package manager
+
 ## 8.0.0
 The package has been converted to an ES module and now requires Node 18 or higher. If you need support for Node 16 or below, please use version 7.x.x.
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,9 @@ replace-in-file $(ls l {,**/}*)  --configFile=config.json
 ```
 
 ## Version information
-From version 8.0.0 onwards, this package requires Node 18 or higher. If you need support for older versions of Node, please use a previous version of this package.
+From version 9.0.0 onwards, this package requires Node 22.12.0 or higher, as older versions of Node have reached end of life. If you need support for older versions of Node, please use a previous version of this package.
+
+From version 8.0.0 onwards, this package requires Node 18 or higher.
 
 As 8.0.0 was a significant rewrite, please [open an issue](https://github.com/adamreisnz/replace-in-file/issues) if you run into any problems or unexpected behaviour.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "test": "mocha 'src/**/*.spec.js'",
+    "lint": "eslint .",
     "coverage": "c8 npm run test",
     "postcoverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html",
     "postversion": "git push && git push --tags && npm publish"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replace-in-file",
   "type": "module",
-  "version": "8.4.0",
+  "version": "9.0.0",
   "description": "A simple utility to quickly replace text in one or more files.",
   "homepage": "https://github.com/adamreisnz/replace-in-file#readme",
   "author": {
@@ -27,7 +27,7 @@
   "bin": "./bin/cli.js",
   "types": "./types/index.d.ts",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "test": "mocha 'src/**/*.spec.js'",
@@ -42,7 +42,7 @@
     "index.js"
   ],
   "dependencies": {
-    "chalk": "^5.6.2",
+    "chalk": "^6.0.0",
     "glob": "^13.0.6",
     "yargs": "^18.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint .",
     "coverage": "c8 npm run test",
     "postcoverage": "open -a \"Google Chrome\" ./coverage/lcov-report/index.html",
-    "postversion": "git push && git push --tags && npm publish"
+    "postversion": "git push && git push --tags"
   },
   "files": [
     "bin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^6.0.0
+        version: 6.0.0
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -228,9 +228,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -879,7 +879,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
+  chalk@6.0.0: {}
 
   check-error@2.1.3: {}
 


### PR DESCRIPTION
## Summary

Lands the already-reviewed content of #219, #220 and #222 on `main`.

Those three stacked PRs were merged, but because their base branches weren't deleted first, GitHub merged each one into the branch below it instead of retargeting to `main` — so only #218 (pnpm) actually reached `main`. This PR cherry-picks the exact same three commits, unchanged, onto current `main`:

1. **v9.0.0 major bump** (#219) — chalk ^6.0.0, engines.node >=22.12.0, version 9.0.0, CHANGELOG + README updates
2. **CI workflow + Dependabot** (#220) — lint & tests on Node 22/24 with pnpm, SHA-pinned actions, weekly Dependabot; adds `lint` script
3. **Trusted publishing** (#222) — `release.yml` publishes on `v*` tags via OIDC with provenance; `postversion` no longer runs `npm publish` (remember the one-time Trusted Publisher setup on npmjs.com: org `adamreisnz`, repo `replace-in-file`, workflow `release.yml`, environment blank)

## Verification
- All 127 tests pass and lint is clean on the cherry-picked result
- `pnpm install --frozen-lockfile` works against current `main`

After merging this, the four `claude/*` feature branches from the previous stack can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)