### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015-2026 Adam Reis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -585,4 +585,6 @@ See the [Changelog](CHANGELOG.md) for more information.
 ## License
 (MIT License)
 
-Copyright 2015-2024, Adam Reis
+Copyright 2015-2026, Adam Reis
+
+See the [LICENSE](LICENSE) file for the full license text.


### PR DESCRIPTION
## Summary

The package declares `"license": "MIT"` in package.json and the README has a copyright line, but the **full MIT licence text was not present anywhere** — not in the repository, and therefore not in the published npm tarball. Some corporate license-compliance scanners flag exactly this (declared licence with no accompanying text).

- Adds a standard `LICENSE` file, MIT, `Copyright (c) 2015-2026 Adam Reis` (start year taken from the first commit in 2015)
- Bumps the README copyright range from 2015-2024 to 2015-2026 and links the new file

## Verification
`npm pack --dry-run` confirms the licence now ships: `npm notice 1.1kB LICENSE`. Note this works **without** touching the `files` directive — npm always includes `LICENSE` in the tarball regardless of `files`.

## Note on branching
Opened against `main` rather than added to #224, since it's unrelated to the TypeScript conversion and can merge immediately without waiting on the stack. Happy to fold it into #224 instead if you'd prefer it in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)