### PR TITLE
ci: build before publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run typecheck
       - run: pnpm test
+      # Build before publishing: npm validates package.json (including the
+      # bin path) before the prepack hook runs, so dist must already exist
+      - run: pnpm run build
       # Trusted publishing requires npm 11.5.1 or higher
       - run: npm install -g npm@latest
-      # Publishes via OIDC (no token) and generates provenance automatically.
-      # The prepack hook builds dist, so no separate build step is needed
+      # Publishes via OIDC (no token) and generates provenance automatically
       - run: npm publish


### PR DESCRIPTION
During the v9.0.0 release, `npm publish` logged:

```
npm warn package-json replace-in-file@9.0.0 No bin file found at dist/bin/cli.js
npm warn publish "bin[replace-in-file]" script name dist/bin/cli.js was invalid and removed
```

npm validates `package.json` **before** the `prepack` hook builds `dist/`, so at validation time the bin target didn't exist. The publish recovered on its own (npm re-validates after prepack — the published 9.0.0 has an intact `bin` and a working CLI, verified from the public registry), but relying on that ordering is fragile.

This restores an explicit `pnpm run build` step before `npm publish`, so the manifest validates cleanly. The prepack hook stays as a safety net for local `npm pack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)